### PR TITLE
解耦，以便独立使用子模块

### DIFF
--- a/DDSocial.podspec
+++ b/DDSocial.podspec
@@ -25,10 +25,8 @@ Pod::Spec.new do |s|
   end
 
   s.subspec 'Wechat' do |wechat|
-    wechat.source_files = 'DDSocial/Wechat/Handler/*.{h,m}','DDSocial/Wechat/WeChatSDK/*.h'
-    wechat.ios.vendored_libraries = 'DDSocial/Wechat/WeChatSDK/*.a'
-    wechat.libraries = 'z', 'sqlite3','stdc++'
-    wechat.frameworks = 'SystemConfiguration','CoreTelephony'
+    wechat.source_files = 'DDSocial/Wechat/*.{h,m}'
+    wechat.dependency 'libWeChatSDK'
     wechat.dependency 'DDSocial/Core'
   end
 
@@ -47,8 +45,9 @@ Pod::Spec.new do |s|
 
   s.subspec 'Twitter' do |twitter|
     twitter.source_files = 'DDSocial/Twitter/*.{h,m}'
-    twitter.dependency 'TwitterKit','~> 1.15.1'
+    twitter.dependency 'TwitterKit','~> 2.0.2'
     twitter.dependency 'DDSocial/Core'
+    twitter.xcconfig = { 'CLANG_ENABLE_MODULES' => 'NO' }
   end
   
   s.subspec 'MiLiao' do |miliao|
@@ -61,24 +60,16 @@ Pod::Spec.new do |s|
     google.source_files = 'DDSocial/Google/*.{h,m}'
     google.dependency 'Google/SignIn', '~> 2.0.3' 
   end
+  
   s.subspec 'MI' do |mi|
     mi.dependency 'DDMISDK', '~> 1.0.1' 
   end
   
   s.subspec 'Share' do |share|
     share.source_files  = 'DDSocial/Handler/DDSocialShareHandler.{h,m}' 
-    share.dependency 'DDSocial/Tencent'
-    share.dependency 'DDSocial/Wechat'
-    share.dependency 'DDSocial/Sina'
-    share.dependency 'DDSocial/Facebook'
-    share.dependency 'DDSocial/Twitter'
-    share.dependency 'DDSocial/MiLiao'
   end
 
   s.subspec 'Auth' do |auth|
     auth.source_files = 'DDSocial/Handler/DDSocialAuthHandler.{h,m}'
-    auth.dependency 'DDSocial/MI'
-    auth.dependency 'DDSocial/Share'
-    auth.dependency 'DDSocial/Google'
   end
 end  

--- a/DDSocial/Core/DDAuthItem.h
+++ b/DDSocial/Core/DDAuthItem.h
@@ -26,8 +26,8 @@
 @property (nonatomic, copy) NSString *thirdId;
 
 /**
- *  @brief 小米授权返回的mac_key
+ *  @brief 其他信息
  */
-@property (nonatomic, copy) NSString *thirdTokenId;
+@property (nonatomic, strong) id userInfo;
 
 @end

--- a/DDSocial/Core/DDAuthItem.m
+++ b/DDSocial/Core/DDAuthItem.m
@@ -19,7 +19,7 @@
 }
 
 - (NSString *)description{
-    return  [NSString stringWithFormat:@"thirdToken:%@\nthirdId:%@\nthirdTokenId:%@\nisCodeAuth:%@\n",self.thirdToken,self.thirdId,self.thirdTokenId,self.isCodeAuth ? @"YES":@"NO"];
+    return  [NSString stringWithFormat:@"thirdToken:%@\nthirdId:%@\nisCodeAuth:%@\n%@\n",self.thirdToken,self.thirdId,self.isCodeAuth ? @"YES":@"NO",self.userInfo];
 }
 
 @end

--- a/DDSocial/Core/DDSocialEventDefs.h
+++ b/DDSocial/Core/DDSocialEventDefs.h
@@ -10,6 +10,8 @@
 #define DDSocialEventDefs_h
 #import "DDSocialTypeDefs.h"
 
+@class DDAuthItem;
+
 /**
  *  @brief  授权事件处理器
  *
@@ -18,7 +20,7 @@
  *  @param result   返回结果
  *  @param error    授权错误信息
  */
-typedef void(^DDSSAuthEventHandler) (DDSSPlatform platform, DDSSAuthState state, id result, NSError *error);
+typedef void(^DDSSAuthEventHandler) (DDSSPlatform platform, DDSSAuthState state, DDAuthItem *authItem, NSError *error);
 
 /**
  *	@brief	分享内容事件处理器

--- a/DDSocial/Core/DDSocialHandlerProtocol.h
+++ b/DDSocial/Core/DDSocialHandlerProtocol.h
@@ -1,0 +1,37 @@
+//
+//  DDSocialHandlerProtocol.h
+//  Pods
+//
+//  Created by CocoaBob on 18/04/16.
+//
+//
+
+#import <Foundation/Foundation.h>
+
+@protocol DDSocialShareContentProtocol;
+@class DDLinkupItem;
+
+@protocol DDSocialHandlerProtocol <NSObject>
+
++ (BOOL)isInstalled;
++ (BOOL)canShare;
+
+- (BOOL)registerWithAppKey:(NSString *)appKey
+                 appSecret:(NSString *)appSecret
+               redirectURL:(NSString *)redirectURL
+            appDescription:(NSString *)appDescription;
+- (BOOL)application:(UIApplication *)application
+      handleOpenURL:(NSURL *)url
+  sourceApplication:(NSString *)sourceApplication
+         annotation:(id)annotation;
+- (BOOL)authWithMode:(DDSSAuthMode)mode
+          controller:(UIViewController *)viewController
+             handler:(DDSSAuthEventHandler)handler;
+- (BOOL)shareWithController:(UIViewController *)viewController
+                 shareScene:(DDSSScene)shareScene
+                contentType:(DDSSContentType)contentType
+                   protocol:(id<DDSocialShareContentProtocol>)protocol
+                    handler:(DDSSShareEventHandler)handler;
+- (BOOL)linkupWithItem:(DDLinkupItem *)linkupItem;
+
+@end

--- a/DDSocial/Facebook/DDFacebookHandler.h
+++ b/DDSocial/Facebook/DDFacebookHandler.h
@@ -10,73 +10,14 @@
 #import "DDSocialEventDefs.h"
 
 @protocol DDSocialShareContentProtocol;
+@protocol DDSocialHandlerProtocol;
 @class UIViewController;
 @class UIApplication;
 
 @interface DDFacebookHandler : NSObject
 
-/**
- *  @brief  判断Facebook客户端是否安装
- *
- *  @return YES ? 已经安装 : 未安装
- */
-+ (BOOL)isFacebookInstalled;
+@end
 
-/**
- *  @brief  判断messenger客户端是否安装
- *
- *  @return YES ? 已经安装 : 未安装
- */
-+ (BOOL)isMessengerInstalled;
-
-/**
- *  @brief  注册Facebook SDK
- */
-- (void)registerApp;
-
-/**
- *  @brief  处理Facebook通过URL启动App时传递的数据
- *
- *  @param application       当前的application
- *  @param url               facebook启动第三方应用时传递过来的URL
- *  @param sourceApplication 唤起该app的app
- *  @param annotation        参数
- *
- *  @return YES ? 唤起成功 : 唤起失败
- */
-- (BOOL)application:(UIApplication *)application
-      handleOpenURL:(NSURL *)url
-  sourceApplication:(NSString *)sourceApplication
-         annotation:(id)annotation;
-
-/**
- *  @brief  微信授权
- *
- *  @param mode           授权的形式
- *  @param viewController 当前ViewController
- *  @param handler        回调方法
- *
- *  @return YES ? 唤起成功 : 唤起失败
- */
-- (BOOL)authWithMode:(DDSSAuthMode)mode
-          controller:(UIViewController *)viewController
-             handler:(DDSSAuthEventHandler)handler;
-
-/**
- *  @brief  分享内容
- *
- *  @param viewController 当前的ViewController
- *  @param protocol       数据组装协议
- *  @param shareScene     分享场景
- *  @param contentType    内容类型
- *  @param handler        回调
- *
- *  @return YES ? 唤起成功 ： 唤起失败
- */
-- (BOOL)shareWithViewController:(UIViewController *)viewController
-                       protocol:(id<DDSocialShareContentProtocol>)protocol
-                     shareScene:(DDSSScene)shareScene
-                    contentType:(DDSSContentType)contentType
-                        handler:(DDSSShareEventHandler)handler;
+@interface DDFacebookHandler (DDSocialHandlerProtocol) <DDSocialHandlerProtocol>
 
 @end

--- a/DDSocial/Google/DDGoogleHandler.h
+++ b/DDSocial/Google/DDGoogleHandler.h
@@ -9,42 +9,14 @@
 #import <Foundation/Foundation.h>
 #import "DDSocialEventDefs.h"
 
+@protocol DDSocialHandlerProtocol;
 @class UIApplication;
 @class UIViewController;
 
 @interface DDGoogleHandler : NSObject
 
-/**
- *  @brief 注册Google
- *
- *  @return YES ? 成功 : 失败
- */
-- (BOOL)registerApp;
+@end
 
-/**
- *  @brief  处理Google通过URL启动App时传递的数据
- *
- *  @param application       当前的application
- *  @param url               facebook启动第三方应用时传递过来的URL
- *  @param sourceApplication 唤起该app的app
- *  @param annotation        参数
- *
- *  @return YES ? 唤起成功 : 唤起失败
- */
-- (BOOL)application:(UIApplication *)application
-      handleOpenURL:(NSURL *)url
-  sourceApplication:(NSString *)sourceApplication
-         annotation:(id)annotation;
-
-/**
- *  @brief Google授权
- *
- *  @param viewController 当前的ViewController
- *  @param handler        回调方法
- *
- *  @return YES ? 唤起成功 : 唤起失败
- */
-- (BOOL)authWithViewController:(UIViewController *)viewController
-                       handler:(DDSSAuthEventHandler)handler;
+@interface DDGoogleHandler (DDSocialHandlerProtocol) <DDSocialHandlerProtocol>
 
 @end

--- a/DDSocial/Handler/DDSocialAuthHandler.m
+++ b/DDSocial/Handler/DDSocialAuthHandler.m
@@ -12,11 +12,7 @@
 #import <GoogleSignIn/GIDGoogleUser.h>
 #import <GoogleSignIn/GIDAuthentication.h>
 
-#import "DDMIHandler.h"
-
 @interface DDSocialAuthHandler ()
-
-@property (nonatomic, strong) DDMIHandler *miHandler;
 
 @end
 
@@ -31,109 +27,19 @@
     return _instance;
 }
 
-- (void)registerMIApp:(NSString *)appid
-          redirectURL:(NSString *)redirectURL{
-    [self.miHandler registerApp:appid withRedirectURL:redirectURL];
-}
-
 - (BOOL)authWithPlatform:(DDSSPlatform)authPlatform
               controller:(UIViewController *)viewController
              authHandler:(DDSSAuthEventHandler)authHandler{
     if (!authHandler) {
         return NO;
     }
-    if (authPlatform == DDSSPlatformMI) {
-        return [self.miHandler authWithType:DDMIAuthResponseTypeCode controller:viewController handler:^(DDMIAuthState state, NSDictionary *response, NSError *error) {
-            switch (state) {
-                case DDMIAuthStateBegan: {
-                    authHandler(authPlatform, DDSSAuthStateBegan, nil, nil);
-                    break;
-                }
-                case DDMIAuthStateSuccess: {
-                    DDAuthItem *authItem = [[DDAuthItem alloc] init];
-                    authItem.thirdToken = [response objectForKey:@"code"];
-                    authHandler(authPlatform, DDSSAuthStateSuccess, authItem, nil);
-                    break;
-                }
-                case DDMIAuthStateFail: {
-                    authHandler(authPlatform, DDSSAuthStateFail, nil, error);
-                    break;
-                }
-                case DDMIAuthStateCancel: {
-                    authHandler(authPlatform, DDSSAuthStateCancel, nil, nil);
-                    break;
-                }
-                default: {
-                    break;
-                }
-            }
-        }];
-    } else {
-        DDSSAuthMode authMode = DDSSAuthModeToken;
-        if (authPlatform == DDSSPlatformWeChat) {
-            authMode = DDSSAuthModeCode;
-        }
-        return [[DDSocialShareHandler sharedInstance] authWithPlatform:authPlatform authMode:authMode controller:viewController handler:^(DDSSPlatform platform, DDSSAuthState state, id result, NSError *error) {
-            DDAuthItem *authItem = nil;
-            if (state == DDSSAuthStateSuccess) {
-                authItem = [self authItemWithResult:result platform:platform];
-            }
-            authHandler(authPlatform, state, authItem, error);
-        }];
+    DDSSAuthMode authMode = DDSSAuthModeToken;
+    if (authPlatform == DDSSPlatformWeChat) {
+        authMode = DDSSAuthModeCode;
     }
+    return [[DDSocialShareHandler sharedInstance] authWithPlatform:authPlatform authMode:authMode controller:viewController handler:^(DDSSPlatform platform, DDSSAuthState state, DDAuthItem *authItem, NSError *error) {
+        authHandler(authPlatform, state, authItem, error);
+    }];
 }
-
-#pragma mark - Private Methods
-
-- (DDAuthItem *)authItemWithResult:(id)result platform:(DDSSPlatform)platform{
-    DDAuthItem *authItem = [[DDAuthItem alloc] init];
-    switch (platform) {
-        case DDSSPlatformWeChat: {
-            authItem.thirdToken = result;
-            break;
-        }
-        case DDSSPlatformQQ: {
-            
-            break;
-        }
-        case DDSSPlatformSina: {
-            
-            break;
-        }
-        case DDSSPlatformFacebook: {
-            FBSDKAccessToken *token = (FBSDKAccessToken *)result;
-            authItem.thirdToken = token.tokenString;
-            authItem.thirdId = token.userID;
-            authItem.isCodeAuth = NO;
-            break;
-        }
-        case DDSSPlatformTwitter: {
-            
-            break;
-        }
-        case DDSSPlatformGoogle:{
-            GIDGoogleUser *googleUser = (GIDGoogleUser *)result;
-            authItem.thirdToken = googleUser.authentication.accessToken;
-            authItem.isCodeAuth = NO;
-            authItem.thirdId = googleUser.userID;
-            break;
-        }
-        default: {
-            break;
-        }
-    }
-    
-    return authItem;
-}
-
-#pragma mark - Getter and Setter
-
-- (DDMIHandler *)miHandler{
-    if (!_miHandler) {
-        _miHandler = [[DDMIHandler alloc] init];
-    }
-    return _miHandler;
-}
-
 
 @end

--- a/DDSocial/Handler/DDSocialShareHandler.h
+++ b/DDSocial/Handler/DDSocialShareHandler.h
@@ -52,10 +52,34 @@
  *  @endcode
  *
  *  @param platform    各应用平台
+ */
+- (void)registerPlatform:(DDSSPlatform)platform;
+
+/**
+ *  @brief  在app启动的时候调用,完成第三方应用的注册
+ *  @code
+ - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
+ *  @endcode
+ *
+ *  @param platform    各应用平台
  *  @param appKey      线下申请的appKey,必传参数
  */
 - (void)registerPlatform:(DDSSPlatform)platform
                   appKey:(NSString *)appKey;
+
+/**
+ *  @brief  在app启动的时候调用,完成第三方应用的注册
+ *  @code
+ - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
+ *  @endcode
+ *
+ *  @param platform    各应用平台
+ *  @param appKey      线下申请的appKey,必传参数
+ *  @param appSecret   线下申请的appSecret,没有则不传
+ */
+- (void)registerPlatform:(DDSSPlatform)platform
+                  appKey:(NSString *)appKey
+               appSecret:(NSString *)appSecret;
 
 /**
  *  @brief  在app启动的时候调用,完成第三方应用的注册

--- a/DDSocial/Handler/DDSocialShareHandler.m
+++ b/DDSocial/Handler/DDSocialShareHandler.m
@@ -7,25 +7,18 @@
 //
 
 #import "DDSocialShareHandler.h"
+#import "DDSocialHandlerProtocol.h"
 #import <UIKit/UIKit.h>
-
-#import "DDWeChatHandler.h"
-#import "DDSinaHandler.h"
-#import "DDTencentHandler.h"
-#import "DDFacebookHandler.h"
-#import "DDGoogleHandler.h"
-#import "DDTwitterHandler.h"
-#import "DDMiLiaoHandler.h"
 
 @interface DDSocialShareHandler ()
 
-@property (nonatomic, strong) DDWeChatHandler   *wechatHandler;
-@property (nonatomic, strong) DDSinaHandler     *sinaHandler;
-@property (nonatomic, strong) DDTencentHandler  *tencentHandler;
-@property (nonatomic, strong) DDFacebookHandler *facebookHandler;
-@property (nonatomic, strong) DDGoogleHandler   *googleHandler;
-@property (nonatomic, strong) DDTwitterHandler  *twitterHandler;
-@property (nonatomic, strong) DDMiLiaoHandler   *miliaoHandler;
+@property (nonatomic, strong) id<DDSocialHandlerProtocol> wechatHandler;
+@property (nonatomic, strong) id<DDSocialHandlerProtocol> sinaHandler;
+@property (nonatomic, strong) id<DDSocialHandlerProtocol> tencentHandler;
+@property (nonatomic, strong) id<DDSocialHandlerProtocol> facebookHandler;
+@property (nonatomic, strong) id<DDSocialHandlerProtocol> googleHandler;
+@property (nonatomic, strong) id<DDSocialHandlerProtocol> twitterHandler;
+@property (nonatomic, strong) id<DDSocialHandlerProtocol> miliaoHandler;
 
 @end
 
@@ -43,45 +36,64 @@
 #pragma mark - Public Methods
 
 + (BOOL)isInstalledPlatform:(DDSSPlatform)platform{
+    Class class = nil;
     if (platform == DDSSPlatformWeChat) {
-        return [DDWeChatHandler isWeChatInstalled];
+        class = NSClassFromString(@"DDWeChatHandler");
     } else if (platform == DDSSPlatformSina){
-        return [DDSinaHandler isSinaInstalled];
+        class = NSClassFromString(@"DDSinaHandler");
     } else if (platform == DDSSPlatformQQ){
-        return [DDTencentHandler isQQInstalled];
+        class = NSClassFromString(@"DDTencentHandler");
     } else if (platform == DDSSPlatformFacebook){
-        return [DDFacebookHandler isFacebookInstalled];
+        class = NSClassFromString(@"DDFacebookHandler");
     } else if (platform == DDSSPlatformTwitter){
-        return [DDTwitterHandler isTwitterInstalled];
+        class = NSClassFromString(@"DDTwitterHandler");
+    } else if (platform == DDSSPlatformGoogle){
+        class = NSClassFromString(@"DDGoogleHandler");
     } else if (platform == DDSSPlatformMiLiao){
-        return [DDMiLiaoHandler isMiLiaoInstalled];
+        class = NSClassFromString(@"DDMiLiaoHandler");
     }
-    return YES;
-}
-
-+ (BOOL)canShareToScence:(DDSSScene)scene{
-    if (scene == DDSSSceneQQFrined || scene == DDSSSceneQZone) {
-        return [self isInstalledPlatform:DDSSPlatformQQ];
-    } else if (scene == DDSSSceneWXSession || scene == DDSSSceneWXTimeline){
-        return [self isInstalledPlatform:DDSSPlatformWeChat];
-    } else if (scene == DDSSSceneSina){
-        return [self isInstalledPlatform:DDSSPlatformSina];
-    } else if (scene == DDSSSceneFBSession){
-        return [DDFacebookHandler isMessengerInstalled];
-    } else if (scene == DDSSSceneFBTimeline){
-        return [self isInstalledPlatform:DDSSPlatformFacebook];
-    } else if (scene == DDSSSceneTwitter){
-        return [self isInstalledPlatform:DDSSPlatformTwitter];
-    } else if (scene == DDSSSceneMiLiaoSession || scene == DDSSSceneMiLiaoTimeline){
-        return [self isInstalledPlatform:DDSSPlatformMiLiao];
+    if (class) {
+        return [class isInstalled];
     } else {
         return NO;
     }
 }
 
++ (BOOL)canShareToScence:(DDSSScene)scene{
+    Class class = nil;
+    if (scene == DDSSSceneWXSession || scene == DDSSSceneWXTimeline) {
+        class = NSClassFromString(@"DDWeChatHandler");
+    } else if (scene == DDSSSceneSina){
+        class = NSClassFromString(@"DDSinaHandler");
+    } else if (scene == DDSSSceneQQFrined || scene == DDSSSceneQZone){
+        class = NSClassFromString(@"DDTencentHandler");
+    } else if (scene == DDSSSceneFBSession){
+        class = NSClassFromString(@"DDFacebookHandler");
+    } else if (scene == DDSSSceneTwitter){
+        class = NSClassFromString(@"DDTwitterHandler");
+    } else if (scene == DDSSSceneMiLiaoSession || scene == DDSSSceneMiLiaoTimeline){
+        class = NSClassFromString(@"DDMiLiaoHandler");
+    }
+    if (class) {
+        return [class canShare];
+    } else {
+        return NO;
+    }
+}
+
+- (void)registerPlatform:(DDSSPlatform)platform {
+    [self registerPlatform:platform appKey:@"" appSecret:@"" redirectURL:@"" appDescription:@""];
+}
+
 - (void)registerPlatform:(DDSSPlatform)platform
                   appKey:(NSString *)appKey{
     [self registerPlatform:platform appKey:appKey appSecret:@"" redirectURL:@"" appDescription:@""];
+}
+
+- (void)registerPlatform:(DDSSPlatform)platform
+                  appKey:(NSString *)appKey
+               appSecret:(NSString *)appSecret {
+    [self registerPlatform:platform appKey:appKey appSecret:appSecret redirectURL:@"" appDescription:@""];
 }
 
 - (void)registerPlatform:(DDSSPlatform)platform
@@ -94,21 +106,21 @@
                   appKey:(NSString *)appKey
                appSecret:(NSString *)appSecret
              redirectURL:(NSString *)redirectURL
-          appDescription:(NSString *)appDescription{
+          appDescription:(NSString *)appDescription {
     if (platform == DDSSPlatformWeChat) {
-        [self.wechatHandler registerApp:appKey withDescription:appDescription];
+        [self.wechatHandler registerWithAppKey:appKey appSecret:appSecret redirectURL:redirectURL appDescription:appDescription];
     } else if (platform == DDSSPlatformSina){
-        [self.sinaHandler registerApp:appKey withRedirectURI:redirectURL];
+        [self.sinaHandler registerWithAppKey:appKey appSecret:appSecret redirectURL:redirectURL appDescription:appDescription];
     } else if (platform == DDSSPlatformQQ){
-        [self.tencentHandler registerApp:appKey];
+        [self.tencentHandler registerWithAppKey:appKey appSecret:appSecret redirectURL:redirectURL appDescription:appDescription];
     } else if (platform == DDSSPlatformFacebook){
-        [self.facebookHandler registerApp];
+        [self.facebookHandler registerWithAppKey:appKey appSecret:appSecret redirectURL:redirectURL appDescription:appDescription];
     } else if (platform == DDSSPlatformGoogle){
-        [self.googleHandler registerApp];
+        [self.googleHandler registerWithAppKey:appKey appSecret:appSecret redirectURL:redirectURL appDescription:appDescription];
     } else if (platform == DDSSPlatformTwitter){
-
+        [self.twitterHandler registerWithAppKey:appKey appSecret:appSecret redirectURL:redirectURL appDescription:appDescription];
     } else if (platform == DDSSPlatformMiLiao){
-        [self.miliaoHandler registerApp];
+        [self.miliaoHandler registerWithAppKey:appKey appSecret:appSecret redirectURL:redirectURL appDescription:appDescription];
     }
 }
 
@@ -116,15 +128,15 @@
       handleOpenURL:(NSURL *)url
   sourceApplication:(NSString *)sourceApplication
          annotation:(id)annotation{
-    BOOL canWeChatOpen = [self.wechatHandler handleOpenURL:url];
+    BOOL canWeChatOpen = [self.wechatHandler application:application handleOpenURL:url sourceApplication:sourceApplication annotation:annotation];
     if (canWeChatOpen) {
         return YES;
     }
-    BOOL canSinaOpen = [self.sinaHandler handleOpenURL:url];
+    BOOL canSinaOpen = [self.sinaHandler application:application handleOpenURL:url sourceApplication:sourceApplication annotation:annotation];
     if (canSinaOpen) {
         return YES;
     }
-    BOOL canQQOpen = [self.tencentHandler handleOpenURL:url];
+    BOOL canQQOpen = [self.tencentHandler application:application handleOpenURL:url sourceApplication:sourceApplication annotation:annotation];
     if (canQQOpen) {
         return YES;
     }
@@ -132,12 +144,15 @@
     if (canFacebookOpen) {
         return YES;
     }
+    BOOL canTwitterOpen = [self.twitterHandler application:application handleOpenURL:url sourceApplication:sourceApplication annotation:annotation];
+    if (canTwitterOpen) {
+        return YES;
+    }
     BOOL canGooleOpen = [self.googleHandler application:application handleOpenURL:url sourceApplication:sourceApplication annotation:annotation];
     if (canGooleOpen) {
         return YES;
     }
-    
-    BOOL canMiliaoOpen = [self.miliaoHandler handleOpenURL:url];
+    BOOL canMiliaoOpen = [self.miliaoHandler application:application handleOpenURL:url sourceApplication:sourceApplication annotation:annotation];
     if (canMiliaoOpen) {
         return YES;
     }
@@ -152,7 +167,6 @@
     return [self application:app handleOpenURL:url sourceApplication:sourceApplicationKey annotation:annotationApplicationKey];
 }
 
-
 - (BOOL)authWithPlatform:(DDSSPlatform)platform
                 authMode:(DDSSAuthMode)authMode
               controller:(UIViewController *)viewController
@@ -160,15 +174,19 @@
     if (platform == DDSSPlatformWeChat) {
         return [self.wechatHandler authWithMode:authMode controller:viewController handler:handler];
     } else if (platform == DDSSPlatformSina){
-        return [self.sinaHandler authWithMode:authMode handler:handler];
+        return [self.sinaHandler authWithMode:authMode controller:viewController handler:handler];
     } else if (platform == DDSSPlatformQQ){
-        return [self.tencentHandler authWithMode:authMode handler:handler];
+        return [self.tencentHandler authWithMode:authMode controller:viewController handler:handler];
     } else if (platform == DDSSPlatformFacebook){
         return [self.facebookHandler authWithMode:authMode controller:viewController handler:handler];
+    } else if (platform == DDSSPlatformTwitter){
+        return [self.twitterHandler authWithMode:authMode controller:viewController handler:handler];
     } else if (platform == DDSSPlatformGoogle){
-        return [self.googleHandler authWithViewController:viewController handler:handler];
+        return [self.googleHandler authWithMode:authMode controller:viewController handler:handler];
+    } else if (platform == DDSSPlatformMiLiao){
+        return [self.miliaoHandler authWithMode:authMode controller:viewController handler:handler];
     }
-    return YES;
+    return NO;
 }
 
 
@@ -182,25 +200,39 @@
         return NO;
     }
     if (platform == DDSSPlatformWeChat) {
-       return [self.wechatHandler shareWithProtocol:protocol shareScene:shareScene contentType:contentType handler:handler];
+       return [self.wechatHandler shareWithController:viewController shareScene:shareScene contentType:contentType protocol:protocol handler:handler];
     } else if (platform == DDSSPlatformSina){
-        return [self.sinaHandler shareWithProtocol:protocol contentType:contentType handler:handler];
+        return [self.sinaHandler shareWithController:viewController shareScene:shareScene contentType:contentType protocol:protocol handler:handler];
     } else if (platform == DDSSPlatformQQ){
-        return [self.tencentHandler shareWithProtocol:protocol shareScene:shareScene contentType:contentType handler:handler];
+        return [self.tencentHandler shareWithController:viewController shareScene:shareScene contentType:contentType protocol:protocol handler:handler];
     } else if (platform == DDSSPlatformFacebook){
-        return [self.facebookHandler shareWithViewController:viewController protocol:protocol shareScene:shareScene contentType:contentType handler:handler];
+        return [self.facebookHandler shareWithController:viewController shareScene:shareScene contentType:contentType protocol:protocol handler:handler];
     } else if (platform == DDSSPlatformTwitter){
-        return [self.twitterHandler shareWithViewController:viewController protocol:protocol contentType:contentType handler:handler];
+        return [self.twitterHandler shareWithController:viewController shareScene:shareScene contentType:contentType protocol:protocol handler:handler];
+    } else if (platform == DDSSPlatformGoogle){
+        return [self.googleHandler shareWithController:viewController shareScene:shareScene contentType:contentType protocol:protocol handler:handler];
     } else if (platform == DDSSPlatformMiLiao){
-        return [self.miliaoHandler shareWithProtocol:protocol shareScene:shareScene contentType:contentType handler:handler];
+        return [self.miliaoHandler shareWithController:viewController shareScene:shareScene contentType:contentType protocol:protocol handler:handler];
     }
-    return YES;
+    return NO;
 }
 
 - (BOOL)linkupWithPlatform:(DDSSPlatform)platform
                       item:(DDLinkupItem *)linkupItem{
     if (platform == DDSSPlatformWeChat) {
-        return [self.wechatHandler JumpToBizProfileWithExtMsg:linkupItem.extMsg username:linkupItem.username profileType:linkupItem.linkupType];
+        return [self.wechatHandler linkupWithItem:linkupItem];
+    } else if (platform == DDSSPlatformSina){
+        return [self.sinaHandler linkupWithItem:linkupItem];
+    } else if (platform == DDSSPlatformQQ){
+        return [self.tencentHandler linkupWithItem:linkupItem];
+    } else if (platform == DDSSPlatformFacebook){
+        return [self.facebookHandler linkupWithItem:linkupItem];
+    } else if (platform == DDSSPlatformTwitter){
+        return [self.twitterHandler linkupWithItem:linkupItem];
+    } else if (platform == DDSSPlatformGoogle){
+        return [self.googleHandler linkupWithItem:linkupItem];
+    } else if (platform == DDSSPlatformMiLiao){
+        return [self.miliaoHandler linkupWithItem:linkupItem];
     }
     return NO;
 }
@@ -253,51 +285,51 @@
 
 #pragma mark - Getter and Setter
 
-- (DDWeChatHandler *)wechatHandler{
+- (id<DDSocialHandlerProtocol>)wechatHandler{
     if (!_wechatHandler) {
-        _wechatHandler = [[DDWeChatHandler alloc] init];
+        _wechatHandler = [NSClassFromString(@"DDWeChatHandler") new];
     }
     return _wechatHandler;
 }
 
-- (DDSinaHandler *)sinaHandler{
+- (id<DDSocialHandlerProtocol>)sinaHandler{
     if (!_sinaHandler) {
-        _sinaHandler = [[DDSinaHandler alloc] init];
+        _sinaHandler = [NSClassFromString(@"DDSinaHandler") new];
     }
     return _sinaHandler;
 }
 
-- (DDTencentHandler *)tencentHandler{
+- (id<DDSocialHandlerProtocol>)tencentHandler{
     if (!_tencentHandler) {
-        _tencentHandler = [[DDTencentHandler alloc] init];
+        _tencentHandler = [NSClassFromString(@"DDTencentHandler") new];
     }
     return _tencentHandler;
 }
 
-- (DDFacebookHandler *)facebookHandler{
+- (id<DDSocialHandlerProtocol>)facebookHandler{
     if (!_facebookHandler) {
-        _facebookHandler = [[DDFacebookHandler alloc] init];
+        _facebookHandler = [NSClassFromString(@"DDFacebookHandler") new];
     }
     return _facebookHandler;
 }
 
-- (DDGoogleHandler *)googleHandler{
+- (id<DDSocialHandlerProtocol>)googleHandler{
     if (!_googleHandler) {
-        _googleHandler = [[DDGoogleHandler alloc] init];
+        _googleHandler = [NSClassFromString(@"DDGoogleHandler") new];
     }
     return _googleHandler;
 }
 
-- (DDTwitterHandler *)twitterHandler{
+- (id<DDSocialHandlerProtocol>)twitterHandler{
     if (!_twitterHandler) {
-        _twitterHandler = [[DDTwitterHandler alloc] init];
+        _twitterHandler = [NSClassFromString(@"DDTwitterHandler") new];
     }
     return _twitterHandler;
 }
 
-- (DDMiLiaoHandler *)miliaoHandler{
+- (id<DDSocialHandlerProtocol>)miliaoHandler{
     if (!_miliaoHandler) {
-        _miliaoHandler = [[DDMiLiaoHandler alloc] init];
+        _miliaoHandler = [NSClassFromString(@"DDMiLiaoHandler") new];
     }
     return _miliaoHandler;
 }

--- a/DDSocial/MiLiao/Handler/DDMiLiaoHandler.h
+++ b/DDSocial/MiLiao/Handler/DDMiLiaoHandler.h
@@ -10,6 +10,7 @@
 #import "DDSocialEventDefs.h"
 
 @protocol DDSocialShareContentProtocol;
+@protocol DDSocialHandlerProtocol;
 
 @interface DDMiLiaoHandler : NSObject
 

--- a/DDSocial/Sina/DDSinaHandler.h
+++ b/DDSocial/Sina/DDSinaHandler.h
@@ -10,59 +10,13 @@
 #import "DDSocialEventDefs.h"
 
 @protocol DDSocialShareContentProtocol;
+@protocol DDSocialHandlerProtocol;
 @class UIViewController;
 
 @interface DDSinaHandler : NSObject
 
-/**
- *  @brief  判断新浪客户端是否安装
- *
- *  @return YES ? 已经安装 : 未安装
- */
-+ (BOOL)isSinaInstalled;
+@end
 
-/**
- *  @brief 向新浪终端程序注册第三方应用
- *
- *  @param appid 新浪开发者ID
- *  @param redirectURI 微博开放平台第三方应用授权回调页地址
- *
- *  @return YES ? 成功 : 失败
- */
-- (BOOL)registerApp:(NSString *)appid withRedirectURI:(NSString *)redirectURI;
-
-
-/**
- *  @brief  处理新浪通过URL启动App时传递的数据
- *
- *  @param url 新浪启动第三方应用时传递过来的URL
- *
- *  @return YES ? 成功返回 : 失败返回
- */
-- (BOOL)handleOpenURL:(NSURL *)url;
-
-/**
- *  @brief  新浪授权
- *
- *  @param mode           授权的形式
- *  @param handler        回调方法
- *
- *  @return YES ? 唤起成功 : 唤起失败
- */
-- (BOOL)authWithMode:(DDSSAuthMode)mode
-             handler:(DDSSAuthEventHandler)handler;
-
-/**
- *  @brief  新浪分享
- *
- *  @param protocol       数据组装协议
- *  @param contentType    内容类型
- *  @param handler        回调
- *
- *  @return YES ? 唤起成功 ： 唤起失败
- */
-- (BOOL)shareWithProtocol:(id<DDSocialShareContentProtocol>)protocol
-              contentType:(DDSSContentType)contentType
-                  handler:(DDSSShareEventHandler)handler;
+@interface DDSinaHandler (DDSocialHandlerProtocol) <DDSocialHandlerProtocol>
 
 @end

--- a/DDSocial/Tencent/Handler/DDTencentHandler.h
+++ b/DDSocial/Tencent/Handler/DDTencentHandler.h
@@ -10,60 +10,12 @@
 #import "DDSocialEventDefs.h"
 
 @protocol DDSocialShareContentProtocol;
+@protocol DDSocialHandlerProtocol;
 
 @interface DDTencentHandler : NSObject
 
-/**
- *  @brief  判断用户手机上是否安装手机QQ
- *
- *  @return YES ? 已经安装 : 未安装
- */
-+ (BOOL)isQQInstalled;
+@end
 
-/**
- *  @brief 向QQ终端程序注册第三方应用
- * 需要在每次启动第三方应用程序时调用。第一次调用后，会在微信的可用应用列表中出现。
- *
- *  @param appid Tencent开发者ID
- *
- *  @return YES ? 成功 : 失败
- */
-- (BOOL)registerApp:(NSString *)appid;
-
-
-/**
- *  @brief  处理QQ通过URL启动App时传递的数据
- *
- *  @param url QQ启动第三方应用时传递过来的URL
- *
- *  @return YES ? 成功返回 : 失败返回
- */
-- (BOOL)handleOpenURL:(NSURL *)url;
-
-/**
- *  @brief  QQ授权
- *
- *  @param mode           授权的形式
- *  @param handler        回调方法
- *
- *  @return YES ? 唤起成功 : 唤起失败
- */
-- (BOOL)authWithMode:(DDSSAuthMode)mode
-             handler:(DDSSAuthEventHandler)handler;
-
-/**
- *  @brief  分享内容
- *
- *  @param protocol       数据组装协议
- *  @param shareScene     分享场景
- *  @param contentType    内容类型
- *  @param handler        回调
- *
- *  @return YES ? 唤起成功 ： 唤起失败
- */
-- (BOOL)shareWithProtocol:(id<DDSocialShareContentProtocol>)protocol
-               shareScene:(DDSSScene)shareScene
-              contentType:(DDSSContentType)contentType
-                  handler:(DDSSShareEventHandler)handler;
+@interface DDTencentHandler (DDSocialHandlerProtocol) <DDSocialHandlerProtocol>
 
 @end

--- a/DDSocial/Twitter/DDTwitterHandler.h
+++ b/DDSocial/Twitter/DDTwitterHandler.h
@@ -10,30 +10,13 @@
 #import "DDSocialEventDefs.h"
 
 @protocol DDSocialShareContentProtocol;
+@protocol DDSocialHandlerProtocol;
 @class UIViewController;
 
 @interface DDTwitterHandler : NSObject
 
-/**
- *  @brief  判断用户手机上是否登录Twitter(使用内置Twitter分享必须判断有没有登录)
- *
- *  @return YES ? 已经安装 : 未安装
- */
-+ (BOOL)isTwitterInstalled;
+@end
 
-/**
- *  @brief  分享内容
- *
- *  @param viewController 当前的ViewController
- *  @param protocol       数据组装协议
- *  @param contentType    内容类型
- *  @param handler        回调
- *
- *  @return YES ? 唤起成功 ： 唤起失败
- */
-- (BOOL)shareWithViewController:(UIViewController *)viewController
-                       protocol:(id<DDSocialShareContentProtocol>)protocol
-                    contentType:(DDSSContentType)contentType
-                        handler:(DDSSShareEventHandler)handler;
+@interface DDTwitterHandler (DDSocialHandlerProtocol) <DDSocialHandlerProtocol>
 
 @end

--- a/DDSocial/Twitter/DDTwitterHandler.m
+++ b/DDSocial/Twitter/DDTwitterHandler.m
@@ -10,6 +10,10 @@
 #import <Social/Social.h>
 
 #import "DDSocialShareContentProtocol.h"
+#import "DDSocialHandlerProtocol.h"
+#import "DDAuthItem.h"
+#import <Fabric/Fabric.h>
+#import <TwitterKit/TwitterKit.h>
 
 @interface DDTwitterHandler ()
 
@@ -19,38 +23,6 @@
 @end
 
 @implementation DDTwitterHandler
-
-+ (BOOL)isTwitterInstalled{
-    return [SLComposeViewController isAvailableForServiceType:SLServiceTypeTwitter];
-}
-
-- (BOOL)shareWithViewController:(UIViewController *)viewController
-                       protocol:(id<DDSocialShareContentProtocol>)protocol
-                    contentType:(DDSSContentType)contentType
-                        handler:(DDSSShareEventHandler)handler{
-    self.viewController = viewController;
-    self.shareEventHandler = handler;
-    
-    if (self.shareEventHandler) {
-        self.shareEventHandler(DDSSPlatformTwitter,DDSSSceneTwitter,DDSSShareStateBegan,nil);
-    }
-
-    if (contentType == DDSSContentTypeText && [protocol conformsToProtocol:@protocol(DDSocialShareTextProtocol)]) {
-        return [self shareTextWithProtocol:(id<DDSocialShareTextProtocol>)protocol];
-    } else if (contentType == DDSSContentTypeImage && [protocol conformsToProtocol:@protocol(DDSocialShareImageProtocol)]){
-        return [self shareImageWithProtocol:(id<DDSocialShareImageProtocol>)protocol];
-    } else if (contentType == DDSSContentTypeWebPage && [protocol conformsToProtocol:@protocol(DDSocialShareWebPageProtocol)]){
-        return [self shareWebPageWithProtocol:(id<DDSocialShareWebPageProtocol>)protocol];
-    } else {
-        if (self.shareEventHandler) {
-            NSString *errorDescription = [NSString stringWithFormat:@"share format error:%@ shareType:%lu",NSStringFromClass([protocol class]),(unsigned long)contentType];
-            NSError *error = [NSError errorWithDomain:@"MiLiao Local Share Error" code:-1 userInfo:@{NSLocalizedDescriptionKey:errorDescription}];
-            self.shareEventHandler(DDSSPlatformTwitter, DDSSSceneTwitter, DDSSShareStateFail, error);
-            self.shareEventHandler = nil;
-        }
-        return NO;
-    }
-}
 
 #pragma mark - Private Methods
 
@@ -106,6 +78,94 @@
     };
     [self.viewController presentViewController:composeViewController animated:YES completion:nil];
     return YES;
+}
+
+@end
+
+@implementation DDTwitterHandler (DDSocialHandlerProtocol)
+
++ (BOOL)isInstalled {
+    return [SLComposeViewController isAvailableForServiceType:SLServiceTypeTwitter];
+}
+
++ (BOOL)canShare {
+    return [SLComposeViewController isAvailableForServiceType:SLServiceTypeTwitter];
+}
+
+- (BOOL)registerWithAppKey:(NSString *)appKey
+                 appSecret:(NSString *)appSecret
+               redirectURL:(NSString *)redirectURL
+            appDescription:(NSString *)appDescription {
+    if (appKey && [appKey length] > 0 && appSecret && [appSecret length] > 0) {
+        [[Twitter sharedInstance] startWithConsumerKey:appKey consumerSecret:appSecret];
+    }
+    [Fabric with:@[[Twitter class]]];
+    return YES;
+}
+
+- (BOOL)application:(UIApplication *)application
+      handleOpenURL:(NSURL *)url
+  sourceApplication:(NSString *)sourceApplication
+         annotation:(id)annotation {
+    return NO;
+}
+
+- (BOOL)authWithMode:(DDSSAuthMode)mode
+          controller:(UIViewController *)viewController
+             handler:(DDSSAuthEventHandler)handler {
+    if (handler) {
+        handler(DDSSPlatformTwitter, DDSSAuthStateBegan, nil, nil);
+    }
+    [[Twitter sharedInstance] logInWithCompletion:^(TWTRSession * _Nullable session, NSError * _Nullable error) {
+        if (error) {
+            if (handler) {
+                handler(DDSSPlatformTwitter, DDSSAuthStateFail, nil, error);
+            }
+        } else {
+            if (handler) {
+                DDAuthItem *authItem = [DDAuthItem new];
+                authItem.thirdToken = session.authToken;
+                authItem.thirdId = session.userID;
+                authItem.userInfo = session;
+                handler(DDSSPlatformTwitter, DDSSAuthStateSuccess, authItem, nil);
+            }
+        }
+    }];
+    return YES;
+}
+
+- (BOOL)shareWithController:(UIViewController *)viewController
+                 shareScene:(DDSSScene)shareScene
+                contentType:(DDSSContentType)contentType
+                   protocol:(id<DDSocialShareContentProtocol>)protocol
+                    handler:(DDSSShareEventHandler)handler {
+    self.viewController = viewController;
+    self.shareEventHandler = handler;
+    
+    if (self.shareEventHandler) {
+        self.shareEventHandler(DDSSPlatformTwitter,DDSSSceneTwitter,DDSSShareStateBegan,nil);
+    }
+    
+    if (contentType == DDSSContentTypeText && [protocol conformsToProtocol:@protocol(DDSocialShareTextProtocol)]) {
+        return [self shareTextWithProtocol:(id<DDSocialShareTextProtocol>)protocol];
+    } else if (contentType == DDSSContentTypeImage && [protocol conformsToProtocol:@protocol(DDSocialShareImageProtocol)]){
+        return [self shareImageWithProtocol:(id<DDSocialShareImageProtocol>)protocol];
+    } else if (contentType == DDSSContentTypeWebPage && [protocol conformsToProtocol:@protocol(DDSocialShareWebPageProtocol)]){
+        return [self shareWebPageWithProtocol:(id<DDSocialShareWebPageProtocol>)protocol];
+    } else {
+        if (self.shareEventHandler) {
+            NSString *errorDescription = [NSString stringWithFormat:@"share format error:%@ shareType:%lu",NSStringFromClass([protocol class]),(unsigned long)contentType];
+            NSError *error = [NSError errorWithDomain:@"MiLiao Local Share Error" code:-1 userInfo:@{NSLocalizedDescriptionKey:errorDescription}];
+            self.shareEventHandler(DDSSPlatformTwitter, DDSSSceneTwitter, DDSSShareStateFail, error);
+            self.shareEventHandler = nil;
+        }
+        return NO;
+    }
+}
+
+- (BOOL)linkupWithPlatform:(DDSSPlatform)platform
+                      item:(DDLinkupItem *)linkupItem {
+    return NO;
 }
 
 @end

--- a/DDSocial/Wechat/Handler/DDWeChatHandler.h
+++ b/DDSocial/Wechat/Handler/DDWeChatHandler.h
@@ -10,76 +10,14 @@
 #import "DDSocialEventDefs.h"
 
 @protocol DDSocialShareContentProtocol;
+@protocol DDSocialHandlerProtocol;
 @class UIViewController;
 
 @interface DDWeChatHandler : NSObject
 
-/**
- *  @brief  判断微信客户端是否安装
- *
- *  @return YES ? 已经安装 : 未安装
- */
-+ (BOOL)isWeChatInstalled;
+@end
 
-/**
- *  @brief 向微信终端程序注册第三方应用
- * 需要在每次启动第三方应用程序时调用。第一次调用后，会在微信的可用应用列表中出现。
- *
- *  @param appid 微信开发者ID
- *  @param appDescription 应用附加信息，长度不超过1024字节
- *
- *  @return YES ? 成功 : 失败
- */
-- (BOOL)registerApp:(NSString *)appid withDescription:(NSString *)appDescription;
-
-/**
- *  @brief  处理微信通过URL启动App时传递的数据
- *
- *  @param url 微信启动第三方应用时传递过来的URL
- *
- *  @return YES ? 成功返回 : 失败返回
- */
-- (BOOL)handleOpenURL:(NSURL *)url;
-
-/**
- *  @brief  微信授权
- *
- *  @param mode           授权的形式
- *  @param viewController 当前ViewController
- *  @param handler        回调方法
- *
- *  @return YES ? 唤起成功 : 唤起失败
- */
-- (BOOL)authWithMode:(DDSSAuthMode)mode
-          controller:(UIViewController *)viewController
-             handler:(DDSSAuthEventHandler)handler;
-
-/**
- *  @brief  微信分享
- *
- *  @param protocol       数据组装协议
- *  @param shareScene     分享场景
- *  @param contentType    内容类型
- *  @param handler        回调
- *
- *  @return YES ? 唤起成功 ： 唤起失败
- */
-- (BOOL)shareWithProtocol:(id<DDSocialShareContentProtocol>)protocol
-               shareScene:(DDSSScene)shareScene
-              contentType:(DDSSContentType)contentType
-                  handler:(DDSSShareEventHandler)handler;
-
-/**
- *  @brief  第三方通知微信，打开指定微信号profile页面
- *
- *  @param extMsg      如果用户加了该公众号为好友，extMsg会上传到服务器
- *  @param userName    跳转到该公众号的profile
- *  @param profileType 跳转的公众号类型
- *
- *  @return YES ? 成功 ： 失败
- */
-- (BOOL)JumpToBizProfileWithExtMsg:(NSString *)extMsg
-                          username:(NSString *)userName
-                       profileType:(int)profileType;
+@interface DDWeChatHandler (DDSocialHandlerProtocol) <DDSocialHandlerProtocol>
 
 @end
+

--- a/DDSocial/Wechat/WeChatSDK/WXApiObject.h
+++ b/DDSocial/Wechat/WeChatSDK/WXApiObject.h
@@ -7,7 +7,6 @@
 //
 
 #import <Foundation/Foundation.h>
-#import <UIKit/UIKit.h>
 
 /*! @brief 错误码
  *
@@ -128,6 +127,39 @@ enum WXMPWebviewType {
 @end
 
 
+
+/*! @brief 第三方向微信终端发起拆企业红包的消息结构体
+ *
+ *  第三方向微信终端发起拆企业红包的消息结构体，微信终端处理后会向第三方返回处理结果
+ * @see HBReq
+ */
+@interface HBReq : BaseReq
+
+/** 随机串，防重发 */
+@property (nonatomic, retain) NSString *nonceStr;
+/** 时间戳，防重发 */
+@property (nonatomic, assign) UInt32 timeStamp;
+/** 商家根据微信企业红包开发文档填写的数据和签名 */
+@property (nonatomic, retain) NSString *package;
+/** 商家根据微信企业红包开发文档对数据做的签名 */
+@property (nonatomic, retain) NSString *sign;
+
+@end
+
+
+
+#pragma mark - HBResp
+/*! @brief 微信终端返回给第三方的关于拆企业红包结果的结构体
+ *
+ *  微信终端返回给第三方的关于拆企业红包结果的结构体
+ */
+@interface HBResp : BaseResp
+
+@end
+
+
+
+
 #pragma mark - SendAuthReq
 /*! @brief 第三方程序向微信终端请求认证的消息结构
  *
@@ -204,6 +236,7 @@ enum WXMPWebviewType {
 @property(nonatomic, retain) NSString* lang;
 @property(nonatomic, retain) NSString* country;
 @end
+
 
 
 #pragma mark - GetMessageFromWXReq
@@ -294,15 +327,6 @@ enum WXMPWebviewType {
 @property (nonatomic, retain) NSString*  sessionFrom;
 @end
 
-#pragma mark - OpenTempSessionResp
-/*! @brief 微信终端向第三方程序返回的OpenTempSessionReq处理结果。
- *
- * 第三方程序向微信终端发送OpenTempSessionReq后，微信发送回来的处理结果，该结果用OpenTempSessionResp表示。
- */
-@interface OpenTempSessionResp : BaseResp
-
-@end
-
 #pragma mark - OpenWebviewReq
 /* ! @brief 第三方通知微信启动内部浏览器，打开指定网页
  *
@@ -322,6 +346,16 @@ enum WXMPWebviewType {
  * 第三方程序向微信终端发送OpenWebviewReq后，微信发送回来的处理结果，该结果用OpenWebviewResp表示
  */
 @interface OpenWebviewResp : BaseResp
+
+@end
+
+
+#pragma mark - OpenTempSessionResp
+/*! @brief 微信终端向第三方程序返回的OpenTempSessionReq处理结果。
+ *
+ * 第三方程序向微信终端发送OpenTempSessionReq后，微信发送回来的处理结果，该结果用OpenTempSessionResp表示。
+ */
+@interface OpenTempSessionResp : BaseResp
 
 @end
 
@@ -395,7 +429,6 @@ enum WXMPWebviewType {
 @property (nonatomic,retain) NSString* cardId;
 /** ext信息
  * @attention 长度不能超过2024字节
- * 具体见http://mp.weixin.qq.com/wiki/7/aaa137b55fb2e0456bf8dd9148dd613f.html#.E9.99.84.E5.BD.954-.E5.8D.A1.E5.88.B8.E6.89.A9.E5.B1.95.E5.AD.97.E6.AE.B5.E5.8F.8A.E7.AD.BE.E5.90.8D.E7.94.9F.E6.88.90.E7.AE.97.E6.B3.95 卡券扩展字段cardExt说明
  */
 @property (nonatomic,retain) NSString* extMsg;
 /**

--- a/DDSocial/Wechat/WeChatSDK/WechatAuthSDK.h
+++ b/DDSocial/Wechat/WeChatSDK/WechatAuthSDK.h
@@ -1,0 +1,64 @@
+//
+//  WechatAuthSDK.h
+//  WechatAuthSDK
+//
+//  Created by 李凯 on 13-11-29.
+//  Copyright (c) 2013年 Tencent. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
+
+enum  AuthErrCode {
+    WechatAuth_Err_Ok = 0,  //Auth成功
+    WechatAuth_Err_NormalErr = -1,  //普通错误
+    WechatAuth_Err_NetworkErr = -2, //网络错误
+    WechatAuth_Err_GetQrcodeFailed = -3,    //获取二维码失败
+    WechatAuth_Err_Cancel = -4,     //用户取消授权
+    WechatAuth_Err_Timeout = -5,    //超时
+};
+
+@protocol WechatAuthAPIDelegate<NSObject>
+@optional
+
+- (void)onAuthGotQrcode:(UIImage *)image;  //得到二维码
+- (void)onQrcodeScanned;    //二维码被扫描
+- (void)onAuthFinish:(int)errCode AuthCode:(NSString *)authCode;    //成功登录
+
+@end
+
+@interface WechatAuthSDK : NSObject{
+    NSString *_sdkVersion;
+    __weak id<WechatAuthAPIDelegate> _delegate;
+}
+
+@property(nonatomic, weak) id<WechatAuthAPIDelegate> delegate;
+@property(nonatomic, readonly) NSString *sdkVersion;   //authSDK版本号
+
+/*! @brief 发送登录请求，等待WechatAuthAPIDelegate回调
+ *
+ * @param appId 微信开发者ID
+ * @param nonceStr 一个随机的尽量不重复的字符串，用来使得每次的signature不同
+ * @param timeStamp 时间戳
+ * @param scope 应用授权作用域，拥有多个作用域用逗号（,）分隔
+ * @param signature 签名
+ * @param schemeData 会在扫码后拼在scheme后
+ * @return 成功返回YES，失败返回NO
+    注:该实现只保证同时只有一个Auth在运行，Auth未完成或未Stop再次调用Auth接口时会返回NO。
+ */
+
+- (BOOL)Auth:(NSString *)appId
+    nonceStr:(NSString *)nonceStr
+   timeStamp:(NSString*)timeStamp
+       scope:(NSString *)scope
+   signature:(NSString *)signature
+  schemeData:(NSString *)schemeData;
+
+
+/*! @brief 暂停登录请求
+ *
+ * @return 成功返回YES，失败返回NO。
+ */
+- (BOOL)StopAuth;
+
+@end


### PR DESCRIPTION
1 解耦的目的，是为了能够任意选用各子模块。
对我来说，是为了不用小米的模块，因为他们的 SDK 尚未支持 bitcode。
解耦之后，若只需要微博功能的话，在自己项目的 Podfile 里做以下设置：

```
pod "DDSocial/Auth",    :git => 'git://github.com/CocoaBob/DDSocial', :commit => 'c96140ba9bf3aba7102c32a18ea37de5d810b258'
pod "DDSocial/Share",   :git => 'git://github.com/CocoaBob/DDSocial', :commit => 'c96140ba9bf3aba7102c32a18ea37de5d810b258'
pod "DDSocial/Sina",    :git => 'git://github.com/CocoaBob/DDSocial', :commit => 'c96140ba9bf3aba7102c32a18ea37de5d810b258'
```

（待 PullRequest 被接受后，只要 `pod "DDSocial/Xxxxx"` 即可）

2 更新了 libWeChatSDK 的 dependency。不过那个名为 libWeChatSDK 的 pod 有几个月没更新了，所以我 fork 了一份。为了获得我的最新版本，需要在自己项目的 Podfile 里做以下设置：

```
pod "libWeChatSDK",     :git => 'git://github.com/CocoaBob/libWeChatSDK', :commit => 'bb4387498ef2974189e8270928f62a1cd3a8ef62'
pod "DDSocial/Wechat",  :git => 'git://github.com/CocoaBob/DDSocial', :commit => 'c96140ba9bf3aba7102c32a18ea37de5d810b258'
```

（待 PullRequest 被接受后，只要 `pod "DDSocial/Wechat"` 即可）

3 添加了微博、腾讯登陆授权后，提取 Open ID 和 Access Code 的代码。
4 更新 Twitter 的 pod 到2.0.2。我甚至怀疑，貌似没必要在 dependency 设置中指定 pod 版本？
5 重构了授权后的回调函数`DDSSAuthEventHandler`，直接返回`DDAuthItem`，并且`DDAuthItem`的第四个参数改成了`id userInfo`，以便附加任意数据。（这里有个问题，`isCodeAuth`属性有什么用？）
6 实现了 Weibo、Tencent、Twitter 登陆后的回调。
7 关于 Twitter
7.1 如果 info.plist 里已经设置过 consumer key 和 consumer secrect 的话，只需要调用下面这句话即完成注册。

``` swift
DDSocialShareHandler.sharedInstance().registerPlatform(.Twitter)
```

7.2 如果没有设置过 info.plist 的话，则调用

``` swift
DDSocialShareHandler.sharedInstance().registerPlatform(.Twitter, appKey: CONSUMER_KEY, appSecret: CONSUMER_SECRET)
```

7.2 如果还要同时注册 Fabric 家的 Crashlytics 等 kit 的话，则需要注意注册顺序，否则会崩溃。尝试下来有两个解决方案：

7.3.1 直接自己完成注册，不用`DDSocialShareHandler`

``` swift
Fabric.with([Crashlytics.self, Twitter.self])
```

7.3.2 先注册 Crashlytics，然后无论配置过 Info.plist 没有，都提供 key 和 secret 来注册 Twitter。

``` swift
Fabric.with([Crashlytics.self])
DDSocialShareHandler.sharedInstance().registerPlatform(.Twitter, appKey: CONSUMER_KEY, appSecret: CONSUMER_SECRET)
```
